### PR TITLE
More Customization and Ability to make use of .then()

### DIFF
--- a/function.js
+++ b/function.js
@@ -1,29 +1,29 @@
-const Discord = require('discord.js')
-const urlJson = require('./json/url.json') 
+const Discord = require('discord.js');
+const urlJson = require('./json/url.json');
 
 exports.antiPhishing = async function(message, embed){
-    if(!message) return console.error('Specify a first parameter (Discord.Message)')
-    if(!embed) return console.error('Specify a second parameter (Discord.MessageEmbed)')
-    if(!message.author && !message.content && !message.member) return console.error('Specify a valid (Discord.Message)')
-    if(embed.length < 2 && !embed.title) return console.error('Specify a valid (Discord.MessageEmbed)')
+    if(!message) return console.error('Specify a first parameter (Discord.Message)');
+    if(!embed) return console.error('Specify a second parameter (Discord.MessageEmbed)');
+    if(!message.author && !message.content && !message.member) return console.error('Specify a valid (Discord.Message)');
+    if(embed.length < 2 && !embed.title) return console.error('Specify a valid (Discord.MessageEmbed)');
 
-    let presente = []
+    let presente = [];
     for(let i = 0; i < urlJson.domains.length; i++){
-        let url = urlJson.domains[i]
+        let url = urlJson.domains[i];
         if(message.content.includes(url)){
-            presente.push(url)
-            break
+            presente.push(url);
+            break;
         }
     }
         
 
     if(presente.length == 1){
-        message.delete()
+        message.delete();
         
-        embed.addField('User:', '`' + message.author.tag + ' | ' + message.author.id + '`')
-        embed.addField('Link:', '`' + presente[0] + '`')
-        embed.setThumbnail(message.author.displayAvatarURL())
+        embed.addField('Link:', '`' + presente[0] + '`');
+        embed.setThumbnail(message.author.displayAvatarURL());
 
-        message.channel.send({embeds: [embed]})
+        message.channel.send({embeds: [embed]});
+        return message;
     }
 }

--- a/function.js
+++ b/function.js
@@ -20,10 +20,13 @@ exports.antiPhishing = async function(message, embed){
     if(presente.length == 1){
         message.delete();
         
-        embed.addField('Link:', '`' + presente[0] + '`');
+        embed.addField('Link:', '||' + presente[0] + '||');
         embed.setThumbnail(message.author.displayAvatarURL());
 
         message.channel.send({embeds: [embed]});
-        return message;
+
+        let res = { message: message, link: presente[0] }
+        
+        return res;
     }
 }


### PR DESCRIPTION
This merge allows the user to add an addField() to the Embed to mention the user, include the user tag, user ID, or customize it how they want.

Secondly, the URL is now a spoiler, that way the link is not shown to the public unless they click on the spoiler.

Added a return res;
The use for this is so that people can create a .then() statement and this statement will allow users to create a log embed that has access to the message and the phishing URL.

(Also added semicolons lol, just a habit)
